### PR TITLE
[feat] 메시지 읽음 확인 기능 추가

### DIFF
--- a/src/service/messageService.js
+++ b/src/service/messageService.js
@@ -78,7 +78,7 @@ const getAllMessageByRoomId = async (roomId, userId) => {
       let message = {
         messageId: rowMessage.id,
         send: Number(rowMessage.sendId) === Number(userId),
-        read: Number(rowMessage.sendId) === Number(userId) ? true : rowMessage.read && true,
+        read: Number(rowMessage.sendId) === Number(userId) ? rowMessage.read && true : false,
         createdAt: rowMessage.createdAt,
         content: rowMessage.content,
       };

--- a/src/service/messageService.js
+++ b/src/service/messageService.js
@@ -51,7 +51,8 @@ const getAllMessageById = async (userId) => {
         roomId: rowMessage.roomId,
         audience: rowMessage.audience,
         audienceId: rowMessage.audienceId,
-        send: Number(rowMessage.sendId) === Number(userId) ? true : false,
+        send: Number(rowMessage.sendId) === Number(userId),
+        read: Number(rowMessage.sendId) === Number(userId) ? true : rowMessage.read && true,
         createdAt: rowMessage.createdAt,
         content: rowMessage.content,
       };
@@ -67,13 +68,17 @@ const getAllMessageById = async (userId) => {
 
 const getAllMessageByRoomId = async (roomId, userId) => {
   try {
+    const cnt = await messageDao.readAllMessage(roomId, userId);
+    if (cnt === null) throw new Error();
+
     const rowMessages = await messageDao.getAllMessageByRoomId(roomId);
     if (rowMessages === null) throw new Error();
 
     const messages = rowMessages.map((rowMessage) => {
       let message = {
         messageId: rowMessage.id,
-        send: Number(rowMessage.sendId) === Number(userId) ? true : false,
+        send: Number(rowMessage.sendId) === Number(userId),
+        read: Number(rowMessage.sendId) === Number(userId) ? true : rowMessage.read && true,
         createdAt: rowMessage.createdAt,
         content: rowMessage.content,
       };


### PR DESCRIPTION
## 🌈 PR 요약 / Linked Issue
- 메시지에 읽었는지 여부를 확인해주는 기능 추가
close #44 


## 📌 변경 사항
- 조금 헷갈려서 코드 리뷰 해주면 좋을 듯
- 일단 ERD의 read 컬럼은 수신자가 읽었는지 여부를 나타냄 (메시지를 보낼 때 default false)

- 내가 나에게 온 전체 메시지를 확인할 경우 (모든 방 표시)
- 이 때 응답으로 보내줄 read는 내가 읽었는지 여부이므로...
  - 내가 **보낸** 쪽지일 경우 `(response의)read`는 무조건 true
  - 내가 받은 쪽지의 경우 해당 메시지의 `(db 테이블의 칼럼)read`는 내가 읽었는지 여부를 나타냄
    - 따라서 read가 true라면  response는 true, 아니라면 false

- 특정 방의 모든 메시지를 확인할 경우 (갠톡)
- 이 때 응답으로 보내줄 read는 상대방이 읽었는지 여부이므로...
  - 내가 **받은** 쪽지의 경우  `(response의)read`는 무조건 true (대화방을 들어가며 모두 읽게됨)
  - 내가 보낸 쪽지의 경우 해당 메시지의 `(db 테이블의 칼럼)read`는 상대방이 읽었는지 여부를 나타냄
    - 따라서 read가 true라면  response는 true, 아니라면 false
