### PR TITLE
[feat] 계정 당 동아리 생성 갯수 제한 기능 추가

### DIFF
--- a/src/constants/responseMessage.js
+++ b/src/constants/responseMessage.js
@@ -49,6 +49,7 @@ module.exports = {
   ALREADY_REGISTERED: '이미 가입한 동아리입니다.',
   READ_REGISTER_INFO_SUCCESS: '동아리 가입정보 가져오기 성공',
   NO_MASTER_USER: '동아리장이 아닙니다.',
+  LIMIT_EXCEED: '갯수 제한을 초과했습니다.',
 
   // 번개
   LIGHT_ADD_SUCCESS: '번개 생성이 완료되었습니다.',

--- a/src/db/crewDao.js
+++ b/src/db/crewDao.js
@@ -25,6 +25,27 @@ const createCrew = async (client, name, code, masterId) => {
 };
 
 /**
+ * getCreatedByUserCount
+ * 해당 유저에 의해서 생성된 동아리의 갯수를 반환하는 메서드
+ * @param {*} masterId - 확인할 유저의 id값
+ * @returns 해당 유저가 생성한 동아리의 갯수
+ */
+const getCreatedByUserCount = async (client, masterId) => {
+  try {
+    const { rows } = await client.query(
+      `
+        select count(*) from crew
+        where master_id = $1
+      `,
+      [masterId],
+    );
+    return convertSnakeToCamel.keysToSnake(rows[0]);
+  } catch (error) {
+    throw new Error('crewDao.getCreatedByUserCount에서 오류 발생: ' + error);
+  }
+};
+
+/**
  * getCrewByCode
  * 가입코드가 인자로 받은 코드와 같은 동아리를 찾아주는 메서드
  * @param code - 가입코드
@@ -109,6 +130,7 @@ const getExistCrew = async (client, crewId) => {
 
 module.exports = {
   createCrew,
+  getCreatedByUserCount,
   getCrewByCode,
   deleteCrewByCrewId,
   getExistCrew,

--- a/src/service/crewService.js
+++ b/src/service/crewService.js
@@ -20,6 +20,12 @@ const createCrew = async (name, masterId) => {
     client = await db.connect(log);
     await client.query('BEGIN');
 
+    // 동아리를 개설하려는 사람이 개설한 동아리의 수 확인
+    const { count: createdByUserCount } = await crewDao.getCreatedByUserCount(client, masterId);
+    if (createdByUserCount >= 5) {
+      return util.fail(statusCode.BAD_REQUEST, responseMessage.LIMIT_EXCEED);
+    }
+
     let code = '';
     let ok = false;
 


### PR DESCRIPTION
## 🌈 PR 요약 / Linked Issue
계정 당 동아리 생성 갯수 제한 기능 추가
close #117


## 📌 변경 사항
- 5개를 초과해서 동아리를 생성 시도시 불가능하도록 구현했습니다.
