### PR TITLE
[feat] 상대방 id값을 통해 채팅방 번호를 가져오는 API 추가

### DIFF
--- a/src/constants/responseMessage.js
+++ b/src/constants/responseMessage.js
@@ -44,6 +44,8 @@ module.exports = {
   NO_ROOM: '채팅방이 없습니다.',
   MESSAGE_READ_SUCCESS: '메시지 불러오기 성공',
   MESSAGE_READ_FAIL: '메시지 불러오기 실패',
+  ROOM_SUCCESS: '방 불러오기 성공',
+  SELF_CHAT: '자신에게 메시지를 보낼 수 없습니다.',
 
   // 동아리
   CREW_CREATE_SUCCESS: '동아리 만들기 성공',

--- a/src/controller/messageController.js
+++ b/src/controller/messageController.js
@@ -5,6 +5,36 @@ const statusCode = require('../constants/statusCode');
 const responseMessage = require('../constants/responseMessage');
 
 /**
+ * GET ~/message/room-exist?recvId=:recvId
+ * 상대방과 대화를 나눈 방 번호를 조회 또는 생성
+ * @private
+ */
+const getRoomIdByUserId = async (req, res) => {
+  try {
+    const sendId = Number(req.user.id);
+    const recvId = Number(req.query.recvId);
+
+    // 수신자 id 빈 값 처리
+    if (!recvId) {
+      return res.status(statusCode.BAD_REQUEST).json(util.fail(statusCode.BAD_REQUEST, responseMessage.NO_USER));
+    }
+
+    // 자기자신에게 보내기 금지
+    if (sendId === recvId) {
+      return res.status(statusCode.BAD_REQUEST).json(util.fail(statusCode.BAD_REQUEST, responseMessage.SELF_CHAT));
+    }
+
+    // 방 생성 or 가져오기
+    const result = await messageService.getRoomIdByUserId(sendId, recvId);
+
+    return res.status(result.status).json(result);
+  } catch (error) {
+    console.log('sendMessage Controller 에러: ' + error);
+    return res.status(statusCode.INTERNAL_SERVER_ERROR).json(util.fail(statusCode.INTERNAL_SERVER_ERROR, responseMessage.INTERNAL_SERVER_ERROR));
+  }
+};
+
+/**
  * POST ~/message
  * 메시지 전송
  * @private
@@ -78,6 +108,7 @@ const getAllMessageByRoomId = async (req, res) => {
 };
 
 module.exports = {
+  getRoomIdByUserId,
   sendMessage,
   getAllMessageById,
   getAllMessageByRoomId,

--- a/src/routes/messageAPI.js
+++ b/src/routes/messageAPI.js
@@ -7,6 +7,7 @@ const router = express.Router();
 router.post('/', authMiddleware, messageController.sendMessage);
 router.get('/', authMiddleware, messageController.getAllMessageById);
 
+router.get('/room-exist', authMiddleware, messageController.getRoomIdByUserId);
 router.get('/:roomId', authMiddleware, messageController.getAllMessageByRoomId);
 
 module.exports = router;


### PR DESCRIPTION
## 🌈 PR 요약 / Linked Issue
클라 요청: 상대방 id값을 통해 채팅방 번호를 가져오는 API 추가
close #137


## 📌 변경 사항
- 상대방 id (recvId)를 통해 채팅방 번호를 가져오는 API추가
  - 이미 대화가 존재한다면 그 방번호를 주고, 아닌 경우 생성한 방번호를 반환
- 기존 메시지 전송 로직 (recvId만 받아서 채팅방 번호는 알아서 관리)은 이 API와 충돌할 부분이 없어 유지하기로 함
